### PR TITLE
feat: expand Windows Volatility3 coverage, fix CLI skip init, and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,46 @@
 [![Volatility3](https://img.shields.io/badge/volatility-3.x-orange)](https://github.com/volatilityfoundation/volatility3)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-AutoTimeliner runs three Volatility3 plugins against a Windows memory image
+AutoTimeliner runs multiple Volatility3 plugins against a Windows memory image
 and merges their output into a single, sorted CSV timeline:
+
+### Core Timeline Plugins
 
 | Plugin | What it captures |
 |---|---|
 | `timeliner` | Timestamps from processes, registry, handles, etc. |
 | `mftscan` | MFT file entries found in memory |
 | `shellbags` | User folder-access history from registry hives |
+
+### Process & Execution Analysis
+
+| Plugin | What it captures |
+|---|---|
+| `psscan` | Active, terminated, and hidden processes with timestamps |
+| `cmdline` | Command-line arguments for each process |
+| `userassist` | Program execution evidence from Windows registry |
+
+### Network Analysis
+
+| Plugin | What it captures |
+|---|---|
+| `netscan` | Network connections with creation timestamps |
+
+### Malware Detection
+
+| Plugin | What it captures |
+|---|---|
+| `malfind` | Code injection and suspicious memory regions |
+| `svcscan` | Windows services (useful for persistence detection) |
+
+### Additional Plugins (opt-in)
+
+| Plugin | What it captures |
+|---|---|
+| `dlllist` | DLLs loaded by each process |
+| `filescan` | Files open in memory at acquisition time |
+| `handles` | Open handles (files, registry keys, mutexes) |
+| `envars` | Environment variables for processes |
 
 ---
 
@@ -23,6 +55,7 @@ and merges their output into a single, sorted CSV timeline:
 |---|---|---|
 | Python | ≥ 3.9 | |
 | [Volatility3](https://github.com/volatilityfoundation/volatility3) | ≥ 2.5 | installed automatically via Poetry/pip |
+| [jsonschema](https://pypi.org/project/jsonschema/) | ≥ 4.0 | enables Volatility3 schema validation and avoids `Dependency for validation unavailable: jsonschema` warning |
 | [mactime](https://www.sleuthkit.org/) | any | **optional** — only needed for `--use-mactime` legacy mode |
 
 > **Target OS of memory images**: Windows only (mftscan and shellbags are Windows-specific plugins).  
@@ -64,6 +97,16 @@ autotimeliner -f IMAGEFILE [-t TIMEFRAME] [-o OUTPUT] [options]
 | `--skip-timeliner` | Skip the timeliner plugin |
 | `--skip-mftscan` | Skip the mftscan plugin |
 | `--skip-shellbags` | Skip the shellbags plugin |
+| `--skip-psscan` | Skip process scanning |
+| `--skip-cmdline` | Skip command-line extraction |
+| `--skip-netscan` | Skip network connection scanning |
+| `--skip-userassist` | Skip program execution evidence |
+| `--skip-svcscan` | Skip Windows services scanning |
+| `--skip-malfind` | Skip malware/injection detection |
+| `--with-dlllist` | Enable DLL analysis (slow) |
+| `--with-filescan` | Enable open files scanning (many records) |
+| `--with-handles` | Enable handle scanning (many records) |
+| `--with-envars` | Enable environment variables extraction |
 | `--use-mactime` | Legacy mode: use external `mactime` binary |
 | `-v`, `--verbose` | Enable debug logging |
 | `--version` | Print version and exit |
@@ -92,6 +135,18 @@ Run only timeliner and shellbags (skip MFT scan):
 
 ```bash
 autotimeliner -f TargetServer.raw --skip-mftscan
+```
+
+Full forensic scan with all plugins enabled:
+
+```bash
+autotimeliner -f TargetServer.raw --with-dlllist --with-filescan --with-handles --with-envars
+```
+
+Quick malware-focused scan:
+
+```bash
+autotimeliner -f TargetServer.raw --skip-timeliner --skip-mftscan --skip-shellbags
 ```
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,12 +4,34 @@
 
 AutoTimeliner automates the creation of a forensic timeline from a Windows volatile memory dump.
 
-It runs three **Volatility3** plugins and merges their output into a single sorted CSV:
+It runs multiple **Volatility3** plugins and merges their output into a single sorted CSV:
 
 ```
-timeliner  ──┐
-mftscan    ──┼──► merge & sort ──► filter by timeframe ──► timeline.csv
-shellbags  ──┘
+┌─────────────────────────────────────────────────┐
+│ Core Timeline Plugins                           │
+│   timeliner, mftscan, shellbags                 │
+├─────────────────────────────────────────────────┤
+│ Process & Execution Analysis                    │
+│   psscan, cmdline, userassist                   │
+├─────────────────────────────────────────────────┤
+│ Network Analysis                                │
+│   netscan                                       │
+├─────────────────────────────────────────────────┤
+│ Malware Detection                               │
+│   malfind, svcscan                              │
+├─────────────────────────────────────────────────┤
+│ Extended Plugins (opt-in)                       │
+│   dlllist, filescan, handles, envars            │
+└─────────────────────────────────────────────────┘
+                      │
+                      ▼
+          merge & sort by timestamp
+                      │
+                      ▼
+           filter by timeframe
+                      │
+                      ▼
+               timeline.csv
 ```
 
 ## Contents

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -31,9 +31,27 @@ and v2 (Volatility3-based) and how to update your workflows.
 | Feature | Flag |
 |---|---|
 | Explicit output path | `-o` / `--output` |
-| Skip individual plugins | `--skip-timeliner`, `--skip-mftscan`, `--skip-shellbags` |
+| Skip core plugins | `--skip-timeliner`, `--skip-mftscan`, `--skip-shellbags`, `--skip-psscan`, `--skip-netscan`, etc. |
+| Enable extended plugins | `--with-dlllist`, `--with-filescan`, `--with-handles`, `--with-envars` |
 | Verbose debug logging | `-v` / `--verbose` |
 | Version string | `--version` |
+
+### New plugins in v2
+
+v2 adds 10 new Volatility3 plugins for comprehensive forensic analysis:
+
+| Plugin | What it captures | Default |
+|---|---|---|
+| `psscan` | Active, terminated, and hidden processes | ✓ ON |
+| `cmdline` | Command-line arguments for processes | ✓ ON |
+| `netscan` | Network connections with timestamps | ✓ ON |
+| `userassist` | Program execution evidence from registry | ✓ ON |
+| `svcscan` | Windows services | ✓ ON |
+| `malfind` | Code injection / malware detection | ✓ ON |
+| `dlllist` | DLLs loaded by processes | opt-in |
+| `filescan` | Open files in memory | opt-in |
+| `handles` | Open handles (files, keys, mutexes) | opt-in |
+| `envars` | Environment variables | opt-in |
 
 ---
 
@@ -58,11 +76,17 @@ and v2 (Volatility3-based) and how to update your workflows.
 autotimeliner -f memory.raw -t 2023-10-17..2023-10-21
 # Internally:
 #   1. volatility3 Python API — automatic symbol table setup + OS/profile probe
-#   2. volatility3.plugins.timeliner.Timeliner    → rows in memory
-#   3. volatility3.plugins.windows.mftscan.MFTScan → rows in memory
+#   2. volatility3.plugins.timeliner.Timeliner       → rows in memory
+#   3. volatility3.plugins.windows.mftscan.MFTScan   → rows in memory
 #   4. volatility3.plugins.windows.shellbags.ShellBags → rows in memory
-#   5. Python sort + timeframe filter
-#   6. csv.writer → timeline.csv  (no mactime, no temp files)
+#   5. volatility3.plugins.windows.psscan.PsScan     → rows in memory
+#   6. volatility3.plugins.windows.cmdline.CmdLine   → rows in memory
+#   7. volatility3.plugins.windows.netscan.NetScan   → rows in memory
+#   8. volatility3.plugins.windows.registry.userassist.UserAssist → rows in memory
+#   9. volatility3.plugins.windows.svcscan.SvcScan   → rows in memory
+#  10. volatility3.plugins.windows.malfind.Malfind   → rows in memory
+#  11. Python sort + timeframe filter
+#  12. csv.writer → timeline.csv  (no mactime, no temp files)
 ```
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,6 +29,7 @@ autotimeliner --help
 
 At startup, AutoTimeliner automatically downloads/installs Volatility3 symbol
 tables (Windows/macOS/Linux) and performs a best-effort memory OS/profile probe.
+Schema validation is enabled via `jsonschema` (included in project dependencies).
 
 ```
 autotimeliner -f IMAGEFILE [-t TIMEFRAME] [-o OUTPUT] [options]
@@ -46,9 +47,34 @@ autotimeliner -f IMAGEFILE [-t TIMEFRAME] [-o OUTPUT] [options]
 |---|---|
 | `-t`, `--timeframe` | Restrict output to `YYYY-MM-DD..YYYY-MM-DD` |
 | `-o`, `--output` | CSV output path (default: `<imagefile>-timeline.csv`) |
+
+#### Core Plugins (enabled by default)
+
+| Flag | Description |
+|---|---|
 | `--skip-timeliner` | Do not run the timeliner plugin |
 | `--skip-mftscan` | Do not run the mftscan plugin |
 | `--skip-shellbags` | Do not run the shellbags plugin |
+| `--skip-psscan` | Do not run process scanning |
+| `--skip-cmdline` | Do not extract command-line arguments |
+| `--skip-netscan` | Do not scan network connections |
+| `--skip-userassist` | Do not extract program execution evidence |
+| `--skip-svcscan` | Do not scan Windows services |
+| `--skip-malfind` | Do not run malware/injection detection |
+
+#### Extended Plugins (disabled by default - opt-in)
+
+| Flag | Description |
+|---|---|
+| `--with-dlllist` | Enable DLL analysis (can be slow) |
+| `--with-filescan` | Enable open files scanning (generates many records) |
+| `--with-handles` | Enable handle scanning (generates many records) |
+| `--with-envars` | Enable environment variables extraction |
+
+#### Other Options
+
+| Flag | Description |
+|---|---|
 | `--use-mactime` | Legacy mode: write body files and call `mactime` (requires SleuthKit) |
 | `-v`, `--verbose` | Show debug-level output |
 | `--version` | Print version string and exit |
@@ -88,6 +114,26 @@ autotimeliner -f '/evidence/*.raw' -t 2023-10-01..2023-10-31
 autotimeliner -f /evidence/memory.raw --skip-shellbags
 ```
 
+### Full forensic scan (all plugins)
+
+```bash
+autotimeliner -f /evidence/memory.raw --with-dlllist --with-filescan --with-handles --with-envars
+```
+
+### Quick malware-focused scan
+
+Run only process, network, and malware detection plugins:
+
+```bash
+autotimeliner -f /evidence/memory.raw --skip-timeliner --skip-mftscan --skip-shellbags
+```
+
+### Network-focused investigation
+
+```bash
+autotimeliner -f /evidence/memory.raw --skip-mftscan --skip-shellbags
+```
+
 ### Verbose debug output
 
 ```bash
@@ -103,9 +149,9 @@ The CSV file contains these columns:
 | Column | Description |
 |---|---|
 | `Timestamp (UTC)` | ISO 8601 timestamp, always UTC |
-| `Source` | Plugin that produced the record (e.g. `timeliner/pslist`, `mftscan`, `shellbags`) |
-| `Description` | File path, process name, registry key, or folder path |
-| `Detail` | Timestamp type (Created/Modified/Accessed/Changed) and extra fields |
+| `Source` | Plugin that produced the record (e.g. `timeliner/pslist`, `mftscan`, `shellbags`, `psscan`, `netscan`, `malfind`) |
+| `Description` | File path, process name, registry key, network connection, or folder path |
+| `Detail` | Timestamp type, PID, network addresses, or extra context |
 | `Inode` | MFT record number (from mftscan; `0` for other sources) |
 | `UID` | User identifier |
 | `GID` | Group identifier |
@@ -119,7 +165,13 @@ Timestamp (UTC),Source,Description,Detail,Inode,UID,GID,Size,Mode
 2023-10-18T09:14:22+00:00,mftscan,\Windows\System32\cmd.exe,Created Date | type=FILE,123456,0,0,368640,----------
 2023-10-18T09:14:23+00:00,shellbags,C:\Users\victim\Desktop,user=victim | Last Write Time,0,0,0,0,----------
 2023-10-18T09:14:25+00:00,timeliner/pslist,cmd.exe (PID 1234),Created Date: 2023-10-18T09:14:25+00:00,0,0,0,0,----------
+2023-10-18T09:14:26+00:00,psscan,Process Created: powershell.exe,PID=5678 PPID=1234 Offset=0x1a2b3c4d,0,0,0,0,----------
+2023-10-18T09:14:30+00:00,netscan,Network TCP ESTABLISHED: 192.168.1.100:49876 → 185.123.45.67:443,PID=5678 Owner=powershell.exe,0,0,0,0,----------
+1970-01-01T00:00:00+00:00,malfind,⚠️ Suspicious Memory: svchost.exe,PID=2468 VPN=0x7ff00000-0x7ff10000 Protection=PAGE_EXECUTE_READWRITE,0,0,0,0,----------
+1970-01-01T00:00:00+00:00,svcscan,Service: MaliciousSvc (Malicious Service),State=Running Start=Auto PID=9999 Binary=C:\Temp\malware.exe,0,0,0,0,----------
 ```
+
+> **Note**: Records from plugins without native timestamps (cmdline, svcscan, filescan, malfind, handles, envars) use `1970-01-01T00:00:00` as a placeholder. These records are still forensically valuable for context.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ packages = [{ include = "autotimeliner", from = "src" }]
 [tool.poetry.dependencies]
 python = "^3.9"
 volatility3 = ">=2.5"
+jsonschema = ">=4.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"

--- a/src/autotimeliner/cli.py
+++ b/src/autotimeliner/cli.py
@@ -125,6 +125,16 @@ def process_image(
     skip_timeliner: bool,
     skip_mftscan: bool,
     skip_shellbags: bool,
+    skip_psscan: bool,
+    skip_cmdline: bool,
+    skip_netscan: bool,
+    skip_userassist: bool,
+    with_dlllist: bool,
+    skip_svcscan: bool,
+    with_filescan: bool,
+    skip_malfind: bool,
+    with_handles: bool,
+    with_envars: bool,
 ) -> None:
     log = logging.getLogger(__name__)
     out_path = output or image_path.parent / (image_path.name + "-timeline.csv")
@@ -148,11 +158,32 @@ def process_image(
 
     effective_skip_mftscan = skip_mftscan
     effective_skip_shellbags = skip_shellbags
+    effective_skip_psscan = skip_psscan
+    effective_skip_cmdline = skip_cmdline
+    effective_skip_netscan = skip_netscan
+    effective_skip_userassist = skip_userassist
+    effective_with_dlllist = with_dlllist
+    effective_skip_svcscan = skip_svcscan
+    effective_with_filescan = with_filescan
+    effective_skip_malfind = skip_malfind
+    effective_with_handles = with_handles
+    effective_with_envars = with_envars
+    
     if os_family != "windows":
-        # mftscan/shellbags are Windows plugins
+        # Windows-specific plugins
         effective_skip_mftscan = True
         effective_skip_shellbags = True
-        log.warning("Detected non-Windows image (%s): forcing --skip-mftscan and --skip-shellbags", os_family)
+        effective_skip_psscan = True
+        effective_skip_cmdline = True
+        effective_skip_netscan = True
+        effective_skip_userassist = True
+        effective_with_dlllist = False
+        effective_skip_svcscan = True
+        effective_with_filescan = False
+        effective_skip_malfind = True
+        effective_with_handles = False
+        effective_with_envars = False
+        log.warning("Detected non-Windows image (%s): Windows-specific plugins disabled", os_family)
 
     log.info("Collecting timeline data from Volatility3 plugins...")
     records = create_timeline(
@@ -160,6 +191,16 @@ def process_image(
         run_timeliner=not skip_timeliner,
         run_mftscan=not effective_skip_mftscan,
         run_shellbags=not effective_skip_shellbags,
+        run_psscan=not effective_skip_psscan,
+        run_cmdline=not effective_skip_cmdline,
+        run_netscan=not effective_skip_netscan,
+        run_userassist=not effective_skip_userassist,
+        run_dlllist=effective_with_dlllist,
+        run_svcscan=not effective_skip_svcscan,
+        run_filescan=effective_with_filescan,
+        run_malfind=not effective_skip_malfind,
+        run_handles=effective_with_handles,
+        run_envars=effective_with_envars,
     )
 
     if not records:
@@ -230,6 +271,56 @@ def main() -> None:
         help="Skip the shellbags plugin",
     )
     parser.add_argument(
+        "--skip-psscan",
+        action="store_true",
+        help="Skip the psscan plugin (process scanning)",
+    )
+    parser.add_argument(
+        "--skip-cmdline",
+        action="store_true",
+        help="Skip the cmdline plugin (command line arguments)",
+    )
+    parser.add_argument(
+        "--skip-netscan",
+        action="store_true",
+        help="Skip the netscan plugin (network connections)",
+    )
+    parser.add_argument(
+        "--skip-userassist",
+        action="store_true",
+        help="Skip the userassist plugin (program execution evidence)",
+    )
+    parser.add_argument(
+        "--with-dlllist",
+        action="store_true",
+        help="Enable dlllist plugin (DLL analysis - can be slow)",
+    )
+    parser.add_argument(
+        "--skip-svcscan",
+        action="store_true",
+        help="Skip the svcscan plugin (Windows services)",
+    )
+    parser.add_argument(
+        "--with-filescan",
+        action="store_true",
+        help="Enable filescan plugin (open files - generates many records)",
+    )
+    parser.add_argument(
+        "--skip-malfind",
+        action="store_true",
+        help="Skip the malfind plugin (malware/injection detection)",
+    )
+    parser.add_argument(
+        "--with-handles",
+        action="store_true",
+        help="Enable handles plugin (open handles - generates many records)",
+    )
+    parser.add_argument(
+        "--with-envars",
+        action="store_true",
+        help="Enable envars plugin (environment variables)",
+    )
+    parser.add_argument(
         "--use-mactime",
         action="store_true",
         help="Legacy mode: use the external mactime binary (requires SleuthKit)",
@@ -271,6 +362,16 @@ def main() -> None:
                 skip_timeliner=args.skip_timeliner,
                 skip_mftscan=args.skip_mftscan,
                 skip_shellbags=args.skip_shellbags,
+                skip_psscan=args.skip_psscan,
+                skip_cmdline=args.skip_cmdline,
+                skip_netscan=args.skip_netscan,
+                skip_userassist=args.skip_userassist,
+                with_dlllist=args.with_dlllist,
+                skip_svcscan=args.skip_svcscan,
+                with_filescan=args.with_filescan,
+                skip_malfind=args.skip_malfind,
+                with_handles=args.with_handles,
+                with_envars=args.with_envars,
             )
         except Exception as exc:  # noqa: BLE001
             logging.getLogger(__name__).error("Failed to process %s: %s", image_file, exc, exc_info=args.verbose)

--- a/src/autotimeliner/timeliner.py
+++ b/src/autotimeliner/timeliner.py
@@ -201,6 +201,445 @@ def collect_shellbags(image_path: str | Path) -> list[TimelineRecord]:
     return records
 
 
+def collect_psscan(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 PsScan plugin and return normalised records.
+
+    PsScan (windows.psscan.PsScan) scans memory for EPROCESS structures,
+    finding both active and terminated/hidden processes with their timestamps.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.psscan.PsScan")
+        if _Plugin is None:
+            raise ImportError("windows.psscan.PsScan not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.psscan plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running psscan plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("psscan"))
+
+    records: list[TimelineRecord] = []
+    for row in rows:
+        # PsScan columns: PID, PPID, ImageFileName, Offset, Threads, Handles,
+        #   SessionId, Wow64, CreateTime, ExitTime
+        pid = str(row.get("PID", ""))
+        ppid = str(row.get("PPID", ""))
+        name = str(row.get("ImageFileName", ""))
+        offset = str(row.get("Offset", ""))
+
+        for ts_col, event_type in [("CreateTime", "Process Created"), ("ExitTime", "Process Exited")]:
+            ts = _to_utc(row.get(ts_col))
+            if ts is None:
+                continue
+            records.append(TimelineRecord(
+                timestamp=ts,
+                source="psscan",
+                description=f"{event_type}: {name}",
+                detail=f"PID={pid} PPID={ppid} Offset={offset}",
+            ))
+
+    log.log(SUCCESS_LEVEL, "PsScan complete: %d records collected", len(records))
+    return records
+
+
+def collect_cmdline(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 CmdLine plugin and return normalised records.
+
+    CmdLine (windows.cmdline.CmdLine) extracts command-line arguments for
+    each running process — useful for detecting malicious parameters.
+
+    Note: CmdLine does not provide timestamps directly. We pair it with
+    process creation times from psscan when available.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.cmdline.CmdLine")
+        if _Plugin is None:
+            raise ImportError("windows.cmdline.CmdLine not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.cmdline plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running cmdline plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("cmdline"))
+
+    # CmdLine doesn't have timestamps, so we return records without timeline value
+    # These are useful for enriching other records but are returned with epoch 0
+    records: list[TimelineRecord] = []
+    epoch_zero = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    for row in rows:
+        # CmdLine columns: PID, Process, Args
+        pid = str(row.get("PID", ""))
+        process = str(row.get("Process", ""))
+        args = str(row.get("Args", ""))
+
+        if not args or args == "N/A":
+            continue
+
+        records.append(TimelineRecord(
+            timestamp=epoch_zero,
+            source="cmdline",
+            description=f"Command Line: {process}",
+            detail=f"PID={pid} Args={args}",
+        ))
+
+    log.log(SUCCESS_LEVEL, "CmdLine complete: %d records collected", len(records))
+    return records
+
+
+def collect_netscan(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 NetScan plugin and return normalised records.
+
+    NetScan (windows.netscan.NetScan) extracts network connections and
+    listening sockets with their creation timestamps — essential for
+    detecting C2 communications and lateral movement.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.netscan.NetScan")
+        if _Plugin is None:
+            raise ImportError("windows.netscan.NetScan not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.netscan plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running netscan plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("netscan"))
+
+    records: list[TimelineRecord] = []
+    for row in rows:
+        # NetScan columns: Offset, Proto, LocalAddr, LocalPort, ForeignAddr,
+        #   ForeignPort, State, PID, Owner, Created
+        proto = str(row.get("Proto", ""))
+        local_addr = str(row.get("LocalAddr", ""))
+        local_port = str(row.get("LocalPort", ""))
+        foreign_addr = str(row.get("ForeignAddr", ""))
+        foreign_port = str(row.get("ForeignPort", ""))
+        state = str(row.get("State", ""))
+        pid = str(row.get("PID", ""))
+        owner = str(row.get("Owner", ""))
+
+        ts = _to_utc(row.get("Created"))
+        if ts is None:
+            continue
+
+        conn_desc = f"{local_addr}:{local_port} → {foreign_addr}:{foreign_port}"
+        records.append(TimelineRecord(
+            timestamp=ts,
+            source="netscan",
+            description=f"Network {proto} {state}: {conn_desc}",
+            detail=f"PID={pid} Owner={owner}",
+        ))
+
+    log.log(SUCCESS_LEVEL, "NetScan complete: %d records collected", len(records))
+    return records
+
+
+def collect_userassist(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 UserAssist plugin and return normalised records.
+
+    UserAssist (windows.registry.userassist.UserAssist) extracts evidence
+    of program execution from the Windows registry, including run counts
+    and last execution timestamps.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.registry.userassist.UserAssist")
+        if _Plugin is None:
+            raise ImportError("windows.registry.userassist.UserAssist not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.registry.userassist plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running userassist plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("userassist"))
+
+    records: list[TimelineRecord] = []
+    for row in rows:
+        # UserAssist columns: Hive Offset, Hive Name, Path, Last Write Time,
+        #   Subkey Name, Value Name, ID, Count, Focus, Time, Last Updated
+        path = str(row.get("Path", ""))
+        value_name = str(row.get("Value Name", ""))
+        count = str(row.get("Count", ""))
+        focus = str(row.get("Focus", ""))
+
+        ts = _to_utc(row.get("Last Updated") or row.get("Last Write Time"))
+        if ts is None:
+            continue
+
+        records.append(TimelineRecord(
+            timestamp=ts,
+            source="userassist",
+            description=f"Program Executed: {value_name}",
+            detail=f"Path={path} Count={count} Focus={focus}",
+        ))
+
+    log.log(SUCCESS_LEVEL, "UserAssist complete: %d records collected", len(records))
+    return records
+
+
+def collect_dlllist(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 DllList plugin and return normalised records.
+
+    DllList (windows.dlllist.DllList) lists DLLs loaded by each process.
+    Useful for detecting DLL injection and suspicious library loads.
+    
+    Note: DllList provides LoadTime for some DLLs.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.dlllist.DllList")
+        if _Plugin is None:
+            raise ImportError("windows.dlllist.DllList not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.dlllist plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running dlllist plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("dlllist"))
+
+    records: list[TimelineRecord] = []
+    for row in rows:
+        # DllList columns: PID, Process, Base, Size, Name, Path, LoadTime
+        pid = str(row.get("PID", ""))
+        process = str(row.get("Process", ""))
+        dll_name = str(row.get("Name", ""))
+        dll_path = str(row.get("Path", ""))
+        base = str(row.get("Base", ""))
+        size = row.get("Size", 0)
+
+        ts = _to_utc(row.get("LoadTime"))
+        if ts is None:
+            continue
+
+        records.append(TimelineRecord(
+            timestamp=ts,
+            source="dlllist",
+            description=f"DLL Loaded: {dll_name}",
+            detail=f"Process={process} PID={pid} Path={dll_path} Base={base}",
+            size=int(size) if size else 0,
+        ))
+
+    log.log(SUCCESS_LEVEL, "DllList complete: %d records collected", len(records))
+    return records
+
+
+def collect_svcscan(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 SvcScan plugin and return normalised records.
+
+    SvcScan (windows.svcscan.SvcScan) extracts Windows services information.
+    Useful for detecting malicious services used for persistence.
+    
+    Note: Services typically don't have individual timestamps in memory,
+    but the presence of unusual services is forensically relevant.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.svcscan.SvcScan")
+        if _Plugin is None:
+            raise ImportError("windows.svcscan.SvcScan not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.svcscan plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running svcscan plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("svcscan"))
+
+    # Services don't have timestamps, return with epoch 0 for reference
+    records: list[TimelineRecord] = []
+    epoch_zero = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    for row in rows:
+        # SvcScan columns: Offset, Order, PID, Start, State, Type, Name, Display, Binary
+        name = str(row.get("Name", ""))
+        display = str(row.get("Display", ""))
+        binary = str(row.get("Binary", ""))
+        state = str(row.get("State", ""))
+        start = str(row.get("Start", ""))
+        pid = str(row.get("PID", ""))
+        svc_type = str(row.get("Type", ""))
+
+        records.append(TimelineRecord(
+            timestamp=epoch_zero,
+            source="svcscan",
+            description=f"Service: {name} ({display})",
+            detail=f"State={state} Start={start} PID={pid} Type={svc_type} Binary={binary}",
+        ))
+
+    log.log(SUCCESS_LEVEL, "SvcScan complete: %d records collected", len(records))
+    return records
+
+
+def collect_filescan(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 FileScan plugin and return normalised records.
+
+    FileScan (windows.filescan.FileScan) scans memory for FILE_OBJECT structures,
+    revealing files that were open at the time of memory acquisition.
+    
+    Note: FileScan doesn't provide timestamps, but file presence is valuable.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.filescan.FileScan")
+        if _Plugin is None:
+            raise ImportError("windows.filescan.FileScan not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.filescan plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running filescan plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("filescan"))
+
+    # FileScan doesn't have timestamps
+    records: list[TimelineRecord] = []
+    epoch_zero = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    for row in rows:
+        # FileScan columns: Offset, Name (file path)
+        offset = str(row.get("Offset", ""))
+        name = str(row.get("Name", ""))
+
+        if not name:
+            continue
+
+        records.append(TimelineRecord(
+            timestamp=epoch_zero,
+            source="filescan",
+            description=f"Open File: {name}",
+            detail=f"Offset={offset}",
+        ))
+
+    log.log(SUCCESS_LEVEL, "FileScan complete: %d records collected", len(records))
+    return records
+
+
+def collect_malfind(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 Malfind plugin and return normalised records.
+
+    Malfind (windows.malfind.Malfind) detects injected code and suspicious
+    memory regions — critical for malware detection.
+    
+    Note: Malfind doesn't provide timestamps, but findings are high-priority.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.malfind.Malfind")
+        if _Plugin is None:
+            raise ImportError("windows.malfind.Malfind not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.malfind plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running malfind plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("malfind"))
+
+    records: list[TimelineRecord] = []
+    epoch_zero = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    for row in rows:
+        # Malfind columns: PID, Process, Start VPN, End VPN, Tag, Protection, CommitCharge, etc.
+        pid = str(row.get("PID", ""))
+        process = str(row.get("Process", ""))
+        start_vpn = str(row.get("Start VPN", ""))
+        end_vpn = str(row.get("End VPN", ""))
+        protection = str(row.get("Protection", ""))
+        tag = str(row.get("Tag", ""))
+
+        records.append(TimelineRecord(
+            timestamp=epoch_zero,
+            source="malfind",
+            description=f"⚠️ Suspicious Memory: {process}",
+            detail=f"PID={pid} VPN={start_vpn}-{end_vpn} Protection={protection} Tag={tag}",
+        ))
+
+    log.log(SUCCESS_LEVEL, "Malfind complete: %d records collected", len(records))
+    return records
+
+
+def collect_handles(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 Handles plugin and return normalised records.
+
+    Handles (windows.handles.Handles) lists open handles for processes,
+    including files, registry keys, mutexes, etc.
+    
+    Note: Handles don't have timestamps, but are useful for context.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.handles.Handles")
+        if _Plugin is None:
+            raise ImportError("windows.handles.Handles not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.handles plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running handles plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("handles"))
+
+    records: list[TimelineRecord] = []
+    epoch_zero = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    for row in rows:
+        # Handles columns: PID, Process, Offset, HandleValue, Type, GrantedAccess, Name
+        pid = str(row.get("PID", ""))
+        process = str(row.get("Process", ""))
+        handle_type = str(row.get("Type", ""))
+        name = str(row.get("Name", ""))
+        granted_access = str(row.get("GrantedAccess", ""))
+
+        if not name or name == "N/A":
+            continue
+
+        records.append(TimelineRecord(
+            timestamp=epoch_zero,
+            source="handles",
+            description=f"Handle ({handle_type}): {name}",
+            detail=f"Process={process} PID={pid} Access={granted_access}",
+        ))
+
+    log.log(SUCCESS_LEVEL, "Handles complete: %d records collected", len(records))
+    return records
+
+
+def collect_envars(image_path: str | Path) -> list[TimelineRecord]:
+    """Run the Vol3 Envars plugin and return normalised records.
+
+    Envars (windows.envars.Envars) extracts environment variables for processes.
+    Useful for detecting suspicious PATH modifications or malware configuration.
+    
+    Note: No timestamps available.
+    """
+    try:
+        _Plugin = get_plugin_class("windows.envars.Envars")
+        if _Plugin is None:
+            raise ImportError("windows.envars.Envars not in plugin registry")
+    except (ImportError, Exception) as exc:
+        log.warning("windows.envars plugin not available — skipping (%s)", exc)
+        return []
+
+    log.info("Running envars plugin…")
+    rows = run_plugin(image_path, _Plugin, progress_callback=_progress("envars"))
+
+    records: list[TimelineRecord] = []
+    epoch_zero = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+    for row in rows:
+        # Envars columns: PID, Process, Block, Variable, Value
+        pid = str(row.get("PID", ""))
+        process = str(row.get("Process", ""))
+        variable = str(row.get("Variable", ""))
+        value = str(row.get("Value", ""))
+
+        # Only capture interesting environment variables
+        interesting_vars = {"PATH", "TEMP", "TMP", "APPDATA", "LOCALAPPDATA", 
+                           "USERPROFILE", "COMSPEC", "SYSTEMROOT"}
+        if variable.upper() not in interesting_vars:
+            continue
+
+        records.append(TimelineRecord(
+            timestamp=epoch_zero,
+            source="envars",
+            description=f"Environment: {variable}",
+            detail=f"Process={process} PID={pid} Value={value[:200]}",  # Truncate long values
+        ))
+
+    log.log(SUCCESS_LEVEL, "Envars complete: %d records collected", len(records))
+    return records
+
+
 # ---------------------------------------------------------------------------
 # Main facade
 # ---------------------------------------------------------------------------
@@ -210,24 +649,54 @@ def create_timeline(
     run_timeliner: bool = True,
     run_mftscan: bool = True,
     run_shellbags: bool = True,
+    run_psscan: bool = True,
+    run_cmdline: bool = True,
+    run_netscan: bool = True,
+    run_userassist: bool = True,
+    run_dlllist: bool = False,      # Disabled by default (can be slow)
+    run_svcscan: bool = True,
+    run_filescan: bool = False,     # Disabled by default (generates many records)
+    run_malfind: bool = True,
+    run_handles: bool = False,      # Disabled by default (generates many records)
+    run_envars: bool = False,       # Disabled by default (generates many records)
 ) -> list[TimelineRecord]:
     """Collect and merge timeline records from all selected plugins.
 
     Returns records sorted by timestamp (ascending).
     """
     records: list[TimelineRecord] = []
-    total_phases = sum([run_timeliner, run_mftscan, run_shellbags])
+    
+    # Count enabled phases
+    phases = [
+        ("timeliner", run_timeliner),
+        ("mftscan", run_mftscan),
+        ("shellbags", run_shellbags),
+        ("psscan", run_psscan),
+        ("cmdline", run_cmdline),
+        ("netscan", run_netscan),
+        ("userassist", run_userassist),
+        ("dlllist", run_dlllist),
+        ("svcscan", run_svcscan),
+        ("filescan", run_filescan),
+        ("malfind", run_malfind),
+        ("handles", run_handles),
+        ("envars", run_envars),
+    ]
+    enabled_phases = [(name, enabled) for name, enabled in phases if enabled]
+    total_phases = len(enabled_phases)
+    
     if total_phases == 0:
         log.warning("No plugins selected for timeline extraction")
         return records
 
     log.info("=" * 70)
-    log.info("Starting comprehensive timeline scan")
+    log.info("Starting comprehensive timeline scan (%d plugins enabled)", total_phases)
     log.info("=" * 70)
 
     scan_phases: list[str] = []
     phase = 1
 
+    # Core timeline plugins
     if run_timeliner:
         log.info("📊 Phase %d/%d: Timeliner Scanning", phase, total_phases)
         timeliner_records = collect_timeliner(image_path)
@@ -247,6 +716,86 @@ def create_timeline(
         shellbags_records = collect_shellbags(image_path)
         records.extend(shellbags_records)
         scan_phases.append(f"ShellBags: {len(shellbags_records)} records")
+        phase += 1
+
+    # Process-related plugins
+    if run_psscan:
+        log.info("🔍 Phase %d/%d: Process Scanning (PsScan)", phase, total_phases)
+        psscan_records = collect_psscan(image_path)
+        records.extend(psscan_records)
+        scan_phases.append(f"PsScan: {len(psscan_records)} records")
+        phase += 1
+
+    if run_cmdline:
+        log.info("💻 Phase %d/%d: Command Line Extraction", phase, total_phases)
+        cmdline_records = collect_cmdline(image_path)
+        records.extend(cmdline_records)
+        scan_phases.append(f"CmdLine: {len(cmdline_records)} records")
+        phase += 1
+
+    # Network plugins
+    if run_netscan:
+        log.info("🌐 Phase %d/%d: Network Scanning", phase, total_phases)
+        netscan_records = collect_netscan(image_path)
+        records.extend(netscan_records)
+        scan_phases.append(f"NetScan: {len(netscan_records)} records")
+        phase += 1
+
+    # Registry plugins
+    if run_userassist:
+        log.info("📜 Phase %d/%d: UserAssist Registry", phase, total_phases)
+        userassist_records = collect_userassist(image_path)
+        records.extend(userassist_records)
+        scan_phases.append(f"UserAssist: {len(userassist_records)} records")
+        phase += 1
+
+    # DLL analysis
+    if run_dlllist:
+        log.info("📦 Phase %d/%d: DLL List", phase, total_phases)
+        dlllist_records = collect_dlllist(image_path)
+        records.extend(dlllist_records)
+        scan_phases.append(f"DllList: {len(dlllist_records)} records")
+        phase += 1
+
+    # Services
+    if run_svcscan:
+        log.info("⚙️ Phase %d/%d: Service Scanning", phase, total_phases)
+        svcscan_records = collect_svcscan(image_path)
+        records.extend(svcscan_records)
+        scan_phases.append(f"SvcScan: {len(svcscan_records)} records")
+        phase += 1
+
+    # File scanning
+    if run_filescan:
+        log.info("📁 Phase %d/%d: File Scanning", phase, total_phases)
+        filescan_records = collect_filescan(image_path)
+        records.extend(filescan_records)
+        scan_phases.append(f"FileScan: {len(filescan_records)} records")
+        phase += 1
+
+    # Malware detection
+    if run_malfind:
+        log.info("🦠 Phase %d/%d: Malware Detection (Malfind)", phase, total_phases)
+        malfind_records = collect_malfind(image_path)
+        records.extend(malfind_records)
+        scan_phases.append(f"Malfind: {len(malfind_records)} records")
+        phase += 1
+
+    # Handle analysis
+    if run_handles:
+        log.info("🔗 Phase %d/%d: Handle Scanning", phase, total_phases)
+        handles_records = collect_handles(image_path)
+        records.extend(handles_records)
+        scan_phases.append(f"Handles: {len(handles_records)} records")
+        phase += 1
+
+    # Environment variables
+    if run_envars:
+        log.info("🌿 Phase %d/%d: Environment Variables", phase, total_phases)
+        envars_records = collect_envars(image_path)
+        records.extend(envars_records)
+        scan_phases.append(f"Envars: {len(envars_records)} records")
+        phase += 1
 
     records.sort(key=lambda r: r.timestamp)
 

--- a/src/autotimeliner/vol3_runner.py
+++ b/src/autotimeliner/vol3_runner.py
@@ -43,6 +43,17 @@ REQUIRED_PLUGIN_MODULES: tuple[str, ...] = (
     "volatility3.plugins.windows.info",
     "volatility3.plugins.linux.banners",
     "volatility3.plugins.mac.bash",
+    # Additional Windows forensic plugins
+    "volatility3.plugins.windows.psscan",
+    "volatility3.plugins.windows.cmdline",
+    "volatility3.plugins.windows.netscan",
+    "volatility3.plugins.windows.registry.userassist",
+    "volatility3.plugins.windows.dlllist",
+    "volatility3.plugins.windows.svcscan",
+    "volatility3.plugins.windows.filescan",
+    "volatility3.plugins.windows.handles",
+    "volatility3.plugins.windows.envars",
+    "volatility3.plugins.windows.malfind",
 )
 
 SYMBOL_TABLE_URLS: dict[str, str] = {


### PR DESCRIPTION
## Summary
Expand Windows Volatility3 forensic coverage, fix CLI skip initialization bug, and refresh docs.

## Changes
- Added collectors: psscan, cmdline, netscan, userassist, dlllist, svcscan, filescan, malfind, handles, envars
- Updated CLI flags and non-Windows plugin gating
- Added jsonschema dependency
- Updated README and docs pages

## Validation
- python3 -m py_compile for updated modules
- Fixed runtime error: effective_skip_mftscan referenced before assignment